### PR TITLE
Support  HuggingFace mirror in download

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ git lfs install
 git clone https://huggingface.co/PixArt-alpha/pixart_sigma_sdxlvae_T5_diffusers output/pixart_sigma_sdxlvae_T5_diffusers
 
 # PixArt-Sigma checkpoints
-python tools/download.py
+python tools/download.py # environment HF_ENDPOINT can use for HuggingFace mirror
 ```
 
 ### 1.3 You are ready to train!

--- a/tools/download.py
+++ b/tools/download.py
@@ -37,8 +37,11 @@ def download_model(model_name):
     assert model_name in pretrained_models
     local_path = f'output/pretrained_models/{model_name}'
     if not os.path.isfile(local_path):
+        hf_endpoint = os.environ.get("HF_ENDPOINT")
+        if hf_endpoint is None:
+            hf_endpoint = "https://huggingface.co"
         os.makedirs('output/pretrained_models', exist_ok=True)
-        web_path = f'https://huggingface.co/PixArt-alpha/PixArt-Sigma/resolve/main/{model_name}'
+        web_path = f'{hf_endpoint}/PixArt-alpha/PixArt-Sigma/resolve/main/{model_name}'
         download_url(web_path, 'output/pretrained_models/')
     model = torch.load(local_path, map_location=lambda storage, loc: storage)
     return model


### PR DESCRIPTION
use HF_ENDPOINT environment to set HuggingFace mirror, can speed up download resource when you have bad network access HuggingFace

e.g. use https://hf-mirror.com/ can speed up download resources in China mainland