### PR TITLE
Store model on CPU during convert_pixart_to_diffusers.py process

### DIFF
--- a/tools/convert_pixart_to_diffusers.py
+++ b/tools/convert_pixart_to_diffusers.py
@@ -22,7 +22,7 @@ interpolation_scale_sigma = {256: 0.5, 512: 1, 1024: 2, 2048: 4}
 
 def main(args):
     interpolation_scale = interpolation_scale_alpha if args.version == "alpha" else interpolation_scale_sigma
-    all_state_dict = torch.load(args.orig_ckpt_path)
+    all_state_dict = torch.load(args.orig_ckpt_path, map_location=torch.device('cpu'))
     state_dict = all_state_dict.pop("state_dict")
     converted_state_dict = {}
 


### PR DESCRIPTION
Loads the torch model into CPU memory for systems with low VRAM available.