### PR TITLE
Make save_model_steps optional in train.py

### DIFF
--- a/train_scripts/train.py
+++ b/train_scripts/train.py
@@ -208,7 +208,7 @@ def train():
             global_step += 1
             data_time_start = time.time()
 
-            if global_step % config.save_model_steps == 0:
+            if config.save_model_steps and global_step % config.save_model_steps == 0:
                 accelerator.wait_for_everyone()
                 if accelerator.is_main_process:
                     os.umask(0o000)


### PR DESCRIPTION
The epochs go very quickly with the smaller models. Saving by steps becomes unnecessary when an epoch completes in an hour on a smaller dataset.

This change modifies save_model logic to not perform when the config's save_model_steps is set to 0.