### PR TITLE
Add config to keep initial noise during validation

### DIFF
--- a/configs/PixArt_xl2_internal.py
+++ b/configs/PixArt_xl2_internal.py
@@ -25,6 +25,8 @@ kv_compress_config = {
 num_workers=4
 train_sampling_steps = 1000
 visualize=False
+# Keep the same seed during validation
+deterministic_validation = False
 eval_sampling_steps = 250
 model_max_length = 120
 lora_rank = 4

--- a/train_scripts/train.py
+++ b/train_scripts/train.py
@@ -57,7 +57,7 @@ def log_validation(model, step, device, vae=None):
     
     for prompt in validation_prompts:
         if validation_noise is not None:
-            z = torch.clone(noise).to(device)
+            z = torch.clone(validation_noise).to(device)
         else:
             z = torch.randn(1, 4, latent_size, latent_size, device=device)
         embed = torch.load(f'output/tmp/{prompt}_{max_length}token.pth', map_location='cpu')

--- a/train_scripts/train.py
+++ b/train_scripts/train.py
@@ -42,7 +42,7 @@ def set_fsdp_env():
 
 
 @torch.inference_mode()
-def log_validation(model, step, device, noise=None, vae=None):
+def log_validation(model, step, device, vae=None):
     torch.cuda.empty_cache()
     model = accelerator.unwrap_model(model).eval()
     hw = torch.tensor([[image_size, image_size]], dtype=torch.float, device=device).repeat(1, 1)
@@ -56,7 +56,7 @@ def log_validation(model, step, device, noise=None, vae=None):
     latents = []
     
     for prompt in validation_prompts:
-        if noise:
+        if validation_noise is not None:
             z = torch.clone(noise).to(device)
         else:
             z = torch.randn(1, 4, latent_size, latent_size, device=device)
@@ -225,7 +225,7 @@ def train():
             if config.visualize and (global_step % config.eval_sampling_steps == 0 or (step + 1) == 1):
                 accelerator.wait_for_everyone()
                 if accelerator.is_main_process:
-                    log_validation(model, global_step, device=accelerator.device, noise=validation_noise, vae=vae)
+                    log_validation(model, global_step, device=accelerator.device, vae=vae)
 
         if epoch % config.save_model_epochs == 0 or epoch == config.num_epochs:
             accelerator.wait_for_everyone()

--- a/train_scripts/train.py
+++ b/train_scripts/train.py
@@ -343,7 +343,7 @@ if __name__ == '__main__':
     logger.info(f"Initializing: {init_train} for training")
     image_size = config.image_size  # @param [256, 512]
     latent_size = int(image_size) // 8
-    validation_noise = torch.randn(1, 4, latent_size, latent_size, device='cpu') if getattr(config, 'deterministic_validation', False)
+    validation_noise = torch.randn(1, 4, latent_size, latent_size, device='cpu') if getattr(config, 'deterministic_validation', False) else None
     pred_sigma = getattr(config, 'pred_sigma', True)
     learn_sigma = getattr(config, 'learn_sigma', True) and pred_sigma
     max_length = config.model_max_length


### PR DESCRIPTION
I found it was useful to reduce the amount of moving parts when testing different learning rates. Seeing how the image changed with a fixed "seed" seemed like the most intuitive way of accomplishing that.