### PR TITLE
Fixed error when calculating latents using VAE

### DIFF
--- a/train_scripts/train_pixart_lora_hf.py
+++ b/train_scripts/train_pixart_lora_hf.py
@@ -810,7 +810,7 @@ def main():
         for step, batch in enumerate(train_dataloader):
             with accelerator.accumulate(transformer):
                 # Convert images to latent space
-                latents = vae.encode(batch["pixel_values"].to(dtype=weight_dtype)).latent_dist.sample()
+                latents = vae.encode(batch["pixel_values"].unsqueeze(0).to(dtype=weight_dtype)).latent_dist.sample()
                 latents = latents * vae.config.scaling_factor
 
                 # Sample noise that we'll add to the latents


### PR DESCRIPTION
VAE is expecting 4 values, i.e, (batch_size, channels, height, width), but we are only passing (channels, height, width), hence adding an extra dimension in the training vectors before generating latent vectors from VAE, as can be seen in the LoRA training script